### PR TITLE
✨ Side bar UI 차단 기능 추가 및 UI 개선

### DIFF
--- a/react-project/src/components/SideBar.jsx
+++ b/react-project/src/components/SideBar.jsx
@@ -5,8 +5,6 @@ import ProfileIcon from "../assets/sticky-note.png";
 
 function Sidebar() {
   const userId = localStorage.getItem("userId");
-
-  // 👇 모든 Hook은 조건문 밖에서 선언!
   const [user, setUser] = useState(null);
   const [posts, setPosts] = useState([]);
   const [textboxes, setTextboxes] = useState([]);
@@ -32,7 +30,7 @@ function Sidebar() {
       .then(setTextboxes);
   }, [userId]);
 
-  // 🔒 로그인 안 된 경우 UI 차단
+  // 로그인 안 된 경우 UI 차단
   if (!userId) {
     return (
       <aside className="fixed top-0 left-0 h-full w-[260px] bg-white/95 border-r border-gray-100 flex flex-col items-center justify-center z-50 shadow">
@@ -69,7 +67,7 @@ function Sidebar() {
    const getPostTitle = (postId) => {
       const postTextboxes = textboxes.filter(t => String(t.postId) === String(postId));
       if (postTextboxes.length === 0) return "Post without title!";
-      // content가 있는 첫 텍스트박스를 찾기
+      // content가 있는 첫 텍스트박스를 찾기, 없을 경우 "Post without title!" 반환
         const nonEmpty = postTextboxes.find(tb => tb.content && tb.content.trim() !== "");
       return nonEmpty ? nonEmpty.content.split("\n")[0] : "Post without title!";
     };


### PR DESCRIPTION
# 📢 Pull Request

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 로그인 하지 않은 유저가 /post/:id 접근 시, 사이드바의 기존 UI 차단 및 로그인 버튼 활성화
- 기본 프로필 이미지(유저의 user.profile 이 비었거나 오류가 생겼을 경우 사용)변경
- post에 textbox 항목이 있지만 content가 비었을 때 빈 포스트라는 제목이 나타나지 않는 버그 수정

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석)
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📋 체크리스트
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 스타일 가이드에 맞게 작성되었나요?
- [x] 불필요한 콘솔 로그나 주석이 제거되었나요?

## 🖼️ 스크린샷 (필요한 경우)
- 변경된 UI가 있다면 스크린샷을 첨부해주세요.

<img width="262" alt="image" src="https://github.com/user-attachments/assets/a30a1480-8269-4fbe-8045-67b5a5e5d040" />

<img width="264" alt="image" src="https://github.com/user-attachments/assets/72a40790-c5b7-4735-8aee-32e5b6d95f1e" />


<!---- ## 🔗 관련 이슈
-  Resolves: #(Isuue Number) 
해결된 이슈가 있을 경우 이 부분 주석을 풀어 작성해주세요 -->

