### PR TITLE
🔐 로그인한 사용자가 /login 접근 시 강제로 페이지 이동 처리 추가

### DIFF
--- a/react-project/src/pages/Login/Login.jsx
+++ b/react-project/src/pages/Login/Login.jsx
@@ -1,9 +1,12 @@
 //이 파일은 로그인 화면을 만드는 코드입니다.
 
 //다른 파일에서 만들어놓은 컴포넌트와 React 기능을 불러옵니다
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import AuthInputBox from "../../components/AuthInputBox"; //아이디 비번 입력 박스
 import CustomButton from "../../components/CustomButton.jsx"; //로그인 버튼
 import useLogin from "./useLogin.js"; //로그인 동작을 처리하는 훅을 가져옴
+
 
 //밑의 함수는 실제로 화면에 보여지는 로그인 컴포넌트
 export default function Login() {
@@ -15,9 +18,27 @@ export default function Login() {
     setPassword,        // 비밀번호를 바꿔주는 함수
     error,              // 에러 메세지( 틀렸을때 뜨는 말 )
     handleLogin,        // 로그인 버튼을 눌렀을 때 실행되는 함수
+    redirectIfLoggedIn, // 로그인된 유저가 로그인 페이지에 접근했을 때 강제로 게시글 화면으로 튕겨냄
   } = useLogin();        // useLogin 훅을 호출하면 위에 값들을 사용할 수 있다
 
 
+  // 페이지가 처음 열릴 때 로그인 상태인 경우, 로그인 페이지에 머무르지 못하게 하고
+  // 자동으로 해당 유저의 최근 글 또는 글쓰기 페이지로 이동시키는 처리
+  const navigate = useNavigate();
+  useEffect(()=> {
+    const userId = localStorage.getItem("userId"); // 로컬 스토리지에서 userId 꺼냄(로그인 되어있는지 확인한다)
+    if (userId){                                   // userId가 존재한다면 = 로그인 되어있다면
+      navigate(`/post/&{1}`, {replace:true})       // 페이지로 강제 이동(replace: 뒤로 가기 방지)
+    }
+  },[]);
+
+  // 로그인 상태일 때, 가장 최근 게시글로 이동하거나 새 글 작성 페이지로 이동시킴
+  // 로그인한 상태로 다시 로그인 페이지 오면 자동 리디렉션
+   useEffect(() => {
+    redirectIfLoggedIn(); //redirectIfLoggedIn을 컴포넌트가 실행되자마자 실행시켜야 함
+  }, []);                 //페이지 열리자마자 로그인 상태면 튕겨내기
+
+  
   return (
     <div className="min-h-screen bg-[#fcfcf8] px-16 pt-20">
       <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-2 text-gray-900">.Yellowmemo</h1>

--- a/react-project/src/pages/Login/useLogin.js
+++ b/react-project/src/pages/Login/useLogin.js
@@ -25,6 +25,20 @@ export default function useLogin() {
         navigate("/login");                         //로그인 페이지로 이동시킴 -> 로그아웃 후 사용자가 다시 로그인할 수 있도록 보내주는거    
     };
 
+    // 유저가 이미 로그인 상태일 경우, 로그인 페이지 접근 시 자동 리다이렉트 시켜주는 함수
+    const redirectIfLoggedIn = async () => {
+        const storedId = getStoredUserId();                         //로컬 스토리지에서 저장된 userId 가져오기
+        if (!storedId) return;                                      //userId가 없으면 = 로그인 안되어있으면 함수종료 
+
+    const recentPost = await getRecentPostByUserId(storedId);       //해당 유저의 최근 글 가져오기 (없으면 null)
+        if (recentPost) {
+            navigate(`/post/${recentPost.id}`, { replace: true });  //최근 글이 있으면 해당 페이지로 이동
+        } else {
+            navigate("/post/create", { replace: true });            //최근 글이 없다면 새 글 작성 페이지로 이동 
+        }
+    };
+
+
 
 
     //로그인 처리 
@@ -54,26 +68,20 @@ export default function useLogin() {
         } catch (err) {
             setError("로그인 중 오류 발생")         //예기치 못한 에러가 생기면 에러 표시
         }
-    
-       
     };
-    // 로컬에 저장되어있는 아이디를 꺼내는 함수를 만들기. 그것도 리턴에 넣으면 다른 컴포넌트에서 쓰면 됨 
-    // 팀원들한테 꼭 이 함수 써서 로그인 확인하라고 하기.
-    
-    // 로그아웃 (로컬스토리지 지우고 로그인페이지)
-
 
     //아래에서는 Login.jsx에서 쓸 수 있게 상태랑 함수를 내보냅니다
 
     return{
-        loginId,      //현재 입력된 Id
-        password,     //현재 입력된 비번
-        setLoginId,   //id변경
-        setPassword,  //비번 변경
-        error,        //에러 
-        handleLogin,  //로그인 실행 
-        getStoredUserId, // 로그인된 유저 Id 가져오기 (로컬스토리지에서)
-        logout,        // 로그아웃 실행 (로컬스토리지 제거, 로그인 페이지 이동)
+        loginId,             //현재 입력된 Id
+        password,            //현재 입력된 비번
+        setLoginId,          //id변경
+        setPassword,         //비번 변경
+        error,               //에러 
+        handleLogin,         //로그인 실행 
+        getStoredUserId,     // 로그인된 유저 Id 가져오기 (로컬스토리지에서)
+        logout,              // 로그아웃 실행 (로컬스토리지 제거, 로그인 페이지 이동)
+        redirectIfLoggedIn,  //로그인된 유저가 로그인 페이지에 접근했을 때 강제로 게시글 화면으로 튕겨냄
     };
 
 }


### PR DESCRIPTION
# 📢 Pull Request

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
원래는 이미 로그인한 사람이 브라우저 뒤로 가기를 누르면 로그인 화면이 다시 나왔습니다
하지만 로그인한 사람이 또 로그인 화면을 보는 건 이상합니다

변경사항:
로그인한 상태로 /login 페이지에 오면, 자동으로 최근에 쓴 게시글 페이지나 새 글 작성 페이지로 보냄
이렇게 하면 로그인한 사람은 다시 로그인 화면을 볼 수 없고, 바로 글 쓰는 화면으로 넘어가게 됩니다

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석)
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📋 체크리스트
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 스타일 가이드에 맞게 작성되었나요?
- [x] 불필요한 콘솔 로그나 주석이 제거되었나요?

## 🖼️ 스크린샷 (필요한 경우)
- 변경된 UI가 있다면 스크린샷을 첨부해주세요.
- 

<!---- ## 🔗 관련 이슈
-  Resolves: #(Isuue Number) 
해결된 이슈가 있을 경우 이 부분 주석을 풀어 작성해주세요 -->

